### PR TITLE
Refactor/upcoming meetings

### DIFF
--- a/Controllers/MeetingsController.cs
+++ b/Controllers/MeetingsController.cs
@@ -223,14 +223,12 @@ public class MeetingsController : ApiController{
             .Select(mp => mp.MeetingId)
             .ToListAsync();
 
-        var upcomingMeetings = await dbContext.Meetings
+        var allMeetings = await dbContext.Meetings
             .Where(m => myOrganizedMeetingsIds.Contains(m.Id) || myParticipantMeetingsIds.Contains(m.Id))
             .OrderBy(m => m.DateTime)
             .ToListAsync();
 
-        upcomingMeetings = IsMeetingArchived(upcomingMeetings, false);
-
-    return Ok(upcomingMeetings);
+    return Ok(allMeetings.GetUpcoming());
     }
 
     [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
@@ -266,26 +264,8 @@ public class MeetingsController : ApiController{
             .OrderBy(m => m.DateTime)
             .ToListAsync();
         //}
-        var archivedMeetings = IsMeetingArchived(myMeetings);
+        var archivedMeetings = myMeetings.GetArchived();
 
         return Ok(archivedMeetings);
-    }
-
-
-    private List<Meeting> IsMeetingArchived(List<Meeting> meetingList, bool archive = true)
-    {
-        List<Meeting> filteredMeetings = new List<Meeting>();
-
-        foreach (var meeting in meetingList)
-        {
-            bool isArchived = archive && meeting.DateTime.AddMinutes(meeting.Duration) < DateTime.Now.ToUniversalTime();
-            bool isUpcoming = !archive && meeting.DateTime.AddMinutes(meeting.Duration) >= DateTime.Now.ToUniversalTime();
-
-            if (isArchived || isUpcoming)
-            {
-                filteredMeetings.Add(meeting);
-            }
-        }
-        return filteredMeetings;
     }
 }

--- a/Controllers/MeetingsController.cs
+++ b/Controllers/MeetingsController.cs
@@ -206,7 +206,7 @@ public class MeetingsController : ApiController{
 
     [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
     [HttpGet]
-    [Route("upcoming")]
+    [Route("my-upcoming")]
     public async Task<IActionResult> GetMyUpcomingMeetings() //so far only for admin/contractor
     {
         var userEmail = HttpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
@@ -233,7 +233,7 @@ public class MeetingsController : ApiController{
 
     [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
     [HttpGet]
-    [Route("archived")]
+    [Route("my-archived")]
     public async Task<IActionResult> GetMyArchivedMeetings() //so far only for admin/contractor
     {
         var userEmail = HttpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;

--- a/Controllers/MeetingsController.cs
+++ b/Controllers/MeetingsController.cs
@@ -207,7 +207,7 @@ public class MeetingsController : ApiController{
     [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
     [HttpGet]
     [Route("upcoming")]
-    public async Task<IActionResult> GetUpcomingMeetings() //so far only for admin/contractor
+    public async Task<IActionResult> GetMyUpcomingMeetings() //so far only for admin/contractor
     {
         var userEmail = HttpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         var user = await userManager.FindByEmailAsync(userEmail!);
@@ -234,7 +234,7 @@ public class MeetingsController : ApiController{
     [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
     [HttpGet]
     [Route("archived")]
-    public async Task<IActionResult> GetArchivedMeetings() //so far only for admin/contractor
+    public async Task<IActionResult> GetMyArchivedMeetings() //so far only for admin/contractor
     {
         var userEmail = HttpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         var user = await userManager.FindByEmailAsync(userEmail!);

--- a/Models/Meeting.cs
+++ b/Models/Meeting.cs
@@ -1,4 +1,18 @@
+using static LinkUpBackend.ServiceErrors.Errors;
+
 namespace LinkUpBackend.Models;
+
+public static class MeetingExtensions
+{
+    public static List<Meeting> GetArchived(this List<Meeting> meetings) {
+        return meetings.Where(meeting => meeting.DateTime.AddMinutes(meeting.Duration) < DateTime.Now.ToUniversalTime()).ToList();
+    }
+    public static List<Meeting> GetUpcoming(this List<Meeting> meetings)
+    {
+        return meetings.Where(meeting => meeting.DateTime.AddMinutes(meeting.Duration) >= DateTime.Now.ToUniversalTime()).ToList();
+    }
+}
+
 public class Meeting{
     public Guid Id {get;set;}
     public DateTime DateTime {get;set;}


### PR DESCRIPTION
The routes meetings/upcoming and meetings/archived have been changed to meetings/my-upcoming and meetings/my-archived to imply that they will respond with owned/joined meetings. 

The way of getting archived and upcoming meetings has been refactored to extension methods for List\<Meeting\>.